### PR TITLE
認証ユーザーの情報を返却するapiの実装

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,27 @@
+from rest_framework.serializers import ModelSerializer
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class UserSerializer(ModelSerializer):
+    """
+    ユーザー情報のシリアライザー
+
+    このシリアライザーはユーザー情報の表示のみを目的としており、
+    すべてのフィールドが読み取り専用に設定されています。
+    ユーザー情報の更新には使用できません。
+    """
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "is_active",
+            "is_staff",
+            "is_superuser",
+        ]
+        read_only_fields = fields  # すべてのフィールドを読み取り専用に設定

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView
+from .views import UserInfoView
 
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("info/", UserInfoView.as_view(), name="user_info"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,29 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from .serializers import UserSerializer
 
-# Create your views here.
+User = get_user_model()
+
+
+class UserInfoView(APIView):
+    """
+    ユーザー情報を取得するAPIビュー
+    認証の有無に関わらずアクセス可能だが、認証状態に応じて異なるレスポンスを返す
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        # リクエストの認証情報を確認
+        if request.user and request.user.is_authenticated:
+            # 認証済みの場合、ユーザー情報を返す
+            serializer = UserSerializer(request.user)
+            return Response(serializer.data)
+        else:
+            # 未認証の場合、メッセージを返す
+            return Response(
+                {"message": "user not authenticated"}, status=status.HTTP_200_OK
+            )


### PR DESCRIPTION
### 概要
このプルリクエストでは、ユーザー情報を取得するためのAPIエンドポイントを実装しました。このAPIは認証状態に関わらずアクセス可能であり、認証済みユーザーにはユーザー情報を返し、未認証ユーザーには認証されていない旨のメッセージを返します。

### 変更内容
- `UserInfoView` APIビューの実装
  - 認証状態を確認し、それに応じたレスポンスを返すロジックの実装
  - 認証済みの場合は、ユーザー情報をシリアライズして返却
  - 未認証の場合は、簡潔なメッセージを返却

- `UserSerializer`の実装
  - セキュリティ考慮のためすべてのフィールドを読み取り専用に設定

- URLルーティングの設定
  - `/accounts/info/` エンドポイントの追加
 
### テスト済み内容
- 認証済みユーザーが正しいユーザー情報を取得できることを確認
- 未認証ユーザーが適切なメッセージを受け取ることを確認
- シリアライザーが必要なフィールドを露出させることを確認

### 関連情報
- 関連Issue: https://github.com/goayasushi/zaiko-be/issues/2