### PR TITLE
サプライヤー詳細・編集・削除機能の実装

### DIFF
--- a/masters/models/supplier.py
+++ b/masters/models/supplier.py
@@ -44,4 +44,4 @@ class Supplier(models.Model):
     class Meta:
         verbose_name = "仕入先"
         verbose_name_plural = "仕入先"
-        ordering = ["created_at"]  # 作成日時順でデフォルト並び替え
+        ordering = ["id"]  # ID順でデフォルト並び替え

--- a/masters/tests/test_supplier_api.py
+++ b/masters/tests/test_supplier_api.py
@@ -493,3 +493,87 @@ class SupplierBulkDeleteAPITest(APITestCase):
 
         # データベースのレコードが削除されていないことを確認
         self.assertEqual(Supplier.objects.count(), 5)
+
+
+class SupplierRetrieveAPITest(APITestCase):
+    """
+    サプライヤー詳細取得APIのテストクラス
+    """
+
+    def setUp(self):
+        """
+        テスト前の準備
+        """
+        # テスト用ユーザーの作成
+        self.user = User.objects.create_user(
+            email="testuser@example.com",
+            password="testpassword123",
+            first_name="Test",
+            last_name="User",
+        )
+
+        # APIクライアントの設定
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        # テスト用サプライヤーデータの作成
+        self.supplier = Supplier.objects.create(
+            supplier_code="TEST123",
+            name="テスト詳細株式会社",
+            contact_person="詳細テスト太郎",
+            phone="03-1234-5678",
+            email="detail@example.com",
+            postal_code="100-0001",
+            prefecture="東京都",
+            city="千代田区",
+            town="丸の内1-1-1",
+            building="詳細ビル10階",
+            website="https://www.detail-test.co.jp",
+            remarks="詳細取得テスト用データ",
+        )
+
+        # サプライヤー詳細取得用のURL
+        self.url = reverse("supplier-detail", args=[self.supplier.id])
+
+    def test_retrieve_supplier(self):
+        """
+        サプライヤー詳細を取得できることをテスト
+        """
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # 各フィールドの値が正しく取得できることを確認
+        self.assertEqual(response.data["id"], self.supplier.id)
+        self.assertEqual(response.data["supplier_code"], self.supplier.supplier_code)
+        self.assertEqual(response.data["name"], self.supplier.name)
+        self.assertEqual(response.data["contact_person"], self.supplier.contact_person)
+        self.assertEqual(response.data["phone"], self.supplier.phone)
+        self.assertEqual(response.data["email"], self.supplier.email)
+        self.assertEqual(response.data["postal_code"], self.supplier.postal_code)
+        self.assertEqual(response.data["prefecture"], self.supplier.prefecture)
+        self.assertEqual(response.data["city"], self.supplier.city)
+        self.assertEqual(response.data["town"], self.supplier.town)
+        self.assertEqual(response.data["building"], self.supplier.building)
+        self.assertEqual(response.data["website"], self.supplier.website)
+        self.assertEqual(response.data["remarks"], self.supplier.remarks)
+
+    def test_retrieve_nonexistent_supplier(self):
+        """
+        存在しないIDのサプライヤー詳細を取得しようとすると404が返ることをテスト
+        """
+        # 存在しないIDのURL
+        nonexistent_url = reverse("supplier-detail", args=[999999])
+
+        response = self.client.get(nonexistent_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_supplier_unauthenticated(self):
+        """
+        未認証ユーザーがサプライヤー詳細を取得できないことをテスト
+        """
+        # クライアントを未認証状態にする
+        self.client.force_authenticate(user=None)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/masters/views/supplier.py
+++ b/masters/views/supplier.py
@@ -1,5 +1,8 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from django.db import transaction
 from masters.models import Supplier
 from masters.serializers import SupplierSerializer
 
@@ -14,8 +17,55 @@ class SupplierViewSet(viewsets.ModelViewSet):
     - 更新（PUT /api/masters/suppliers/{id}/）
     - 部分更新（PATCH /api/masters/suppliers/{id}/）
     - 削除（DELETE /api/masters/suppliers/{id}/）
+    - 一括削除（POST /api/masters/suppliers/bulk_delete/）
     """
 
     queryset = Supplier.objects.all()
     serializer_class = SupplierSerializer
     permission_classes = [IsAuthenticated]
+
+    @action(methods=["post"], detail=False)
+    def bulk_delete(self, request):
+        """
+        複数のサプライヤーを一括で削除する
+
+        リクエストボディに以下の形式でIDリストを含める:
+        {
+            "ids": [1, 2, 3]
+        }
+
+        Returns:
+            Response: 削除結果のレスポンス
+        """
+        ids = request.data.get("ids", [])
+        if not ids:
+            return Response(
+                {"error": "削除対象のIDリストが空です"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 対象のサプライヤーが存在するか確認
+        suppliers = Supplier.objects.filter(id__in=ids)
+        count_to_delete = suppliers.count()  # 削除前にカウント
+
+        if count_to_delete != len(ids):
+            return Response(
+                {"error": "指定されたIDの一部が存在しません"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            # トランザクションを使用して一括削除
+            with transaction.atomic():
+                # 削除前に参照整合性チェックなどが必要な場合はここで実装
+                suppliers.delete()
+
+            return Response(
+                {"message": f"{count_to_delete}件のサプライヤーを削除しました"},
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            return Response(
+                {"error": f"削除中にエラーが発生しました: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/masters/views/supplier.py
+++ b/masters/views/supplier.py
@@ -24,7 +24,7 @@ class SupplierViewSet(viewsets.ModelViewSet):
     serializer_class = SupplierSerializer
     permission_classes = [IsAuthenticated]
 
-    @action(methods=["post"], detail=False)
+    @action(methods=["post"], detail=False, url_path="bulk-delete")
     def bulk_delete(self, request):
         """
         複数のサプライヤーを一括で削除する


### PR DESCRIPTION
## 概要

このプルリクエストでは、サプライヤー（仕入先）の詳細表示、更新、一括削除機能・テストを実装しました。複数のサプライヤーを一度に削除する機能を提供するAPIエンドポイントを追加しています。

## 変更内容

- サプライヤーの一括削除機能の実装
  - POST `/api/masters/suppliers/bulk-delete/` - 複数のサプライヤーを一度に削除
  - トランザクション処理によるデータ整合性の確保
  - URLパスをケバブケース形式に統一

- テストコード
  - `SupplierRetrieveAPITest` - 詳細取得APIのテスト実装
  - `SupplierUpdateAPITest` - 更新APIのテスト実装（PUT/PATCH）
  - `SupplierBulkDeleteAPITest` - 一括削除APIのテスト実装

## 関連情報
- 関連Issue: https://github.com/goayasushi/zaiko-be/issues/15