### PR TITLE
Feature/parts list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 Dockerfile
 .gitignore
 **/__pycache__/
+seed_data.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 
 # cursor
 .cursorrules
+
+# seed
+seed_data.sh


### PR DESCRIPTION
## 概要

このプルリクエストでは、部品一覧取得 API のテストを追加し、テスト用データ登録スクリプト (`seed_data.sh`) をプロジェクトに含めるために `.gitignore`／`.dockerignore` を更新しました。

## 変更内容

* **`.dockerignore` / `.gitignore`の更新**

  * `seed_data.sh` を対象に追加

* **`masters/tests/test_part_api.py`** に部品一覧取得 API のテストケースを追加（約250 行）

  * `PartListAPITest` クラスを新規作成

    * `test_list_parts`：ベーシックな一覧取得レスポンスと件数検証
    * `test_list_parts_pagination`：ページネーション（20 件／ページ）の動作確認
    * `test_custom_pagination_format`：`current`／`total_pages`／`page_size` などカスタムフィールドの存在と値検証
    * `test_list_parts_unauthenticated`：認証なしアクセスに対する 401 応答確認
    * `test_list_parts_fields`：レスポンスに含まれる各フィールド（`name`, `category`, `supplier`, `cost_price` など）の整合性チェック
    * `test_list_parts_supplier_nested_data`：サプライヤー情報がネストされて返ることを検証
    * `test_list_parts_empty`：部品が未登録の場合に空の結果が返ることを検証


## 関連情報

* 関連Issue: https://github.com/goayasushi/zaiko-be/issues/11
